### PR TITLE
Use tmpdir for uploads and clean up pdf files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN npm install
 # Copy app source
 COPY . .
 
-EXPOSE 3000
+EXPOSE 10000
 CMD [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd pdf-decryptor-service
 4. Use this repo
 5. Select:
    - **Environment**: Docker
-   - **Port**: 3000
+   - **Port**: 10000
    - Leave the rest as defaults
 6. Click **Deploy**
 
@@ -78,7 +78,7 @@ node server.js
 Then, in another terminal:
 
 ```bash
-curl -X POST http://localhost:3000/decrypt   -F "pdf=@path/to/locked.pdf"   -F "password=YOUR_PASSWORD" --output decrypted.pdf
+curl -X POST http://localhost:10000/decrypt   -F "pdf=@path/to/locked.pdf"   -F "password=YOUR_PASSWORD" --output decrypted.pdf
 ```
 
 ---


### PR DESCRIPTION
## Summary
- store uploads in the system temp directory
- delete temporary PDFs after qpdf finishes
- update docs and Dockerfile for port 10000

## Testing
- `node --check server.js`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6871f207ec68832082ba726257d2e216