### PR TITLE
Add .dockerignore for smaller Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+README.md
+.github


### PR DESCRIPTION
## Summary
- ensure Docker builds don't include dev files by ignoring `.git`, `node_modules`, and miscellaneous project files

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687224da52148320ba27cf4dc5d66a60